### PR TITLE
feat: add Claude Code plugin marketplace structure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,35 @@
+{
+  "name": "estonia-ai-kit",
+  "owner": {
+    "name": "Stefano Amorelli",
+    "email": "stefano@amorelli.tech"
+  },
+  "metadata": {
+    "description": "Claude Code plugins for Estonian digital services. Banking, tax, business registry, and more.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "lhv",
+      "source": "./plugins/lhv",
+      "description": "LHV Bank CLI skill. Authenticate with Smart-ID, view accounts and transactions, switch between personal and business profiles, and make SEPA payments.",
+      "version": "0.1.0",
+      "author": { "name": "Stefano Amorelli" },
+      "repository": "https://github.com/stefanoamorelli/estonia-ai-kit",
+      "license": "AGPL-3.0",
+      "keywords": ["banking", "lhv", "estonia", "smart-id", "sepa"],
+      "category": "finance"
+    },
+    {
+      "name": "emta",
+      "source": "./plugins/emta",
+      "description": "EMTA (Estonian Tax and Customs Board) CLI skill. Authenticate via Smart-ID, list and view TSD declarations.",
+      "version": "0.1.0",
+      "author": { "name": "Stefano Amorelli" },
+      "repository": "https://github.com/stefanoamorelli/estonia-ai-kit",
+      "license": "AGPL-3.0",
+      "keywords": ["tax", "emta", "estonia", "smart-id", "tsd"],
+      "category": "finance"
+    }
+  ]
+}

--- a/plugins/emta/.claude-plugin/plugin.json
+++ b/plugins/emta/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "emta",
+  "description": "EMTA (Estonian Tax and Customs Board) CLI skill. Authenticate via Smart-ID, list and view TSD declarations.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Stefano Amorelli",
+    "email": "stefano@amorelli.tech"
+  },
+  "homepage": "https://amorelli.tech",
+  "repository": "https://github.com/stefanoamorelli/estonia-ai-kit",
+  "license": "AGPL-3.0"
+}

--- a/plugins/emta/README.md
+++ b/plugins/emta/README.md
@@ -1,0 +1,41 @@
+# EMTA Plugin for Claude Code
+
+Claude Code plugin for interacting with the Estonian Tax and Customs Board (EMTA). Authenticate via Smart-ID QR code, list and view TSD (Income and Social Tax Return) declarations.
+
+> [!IMPORTANT]
+> This plugin is experimental and not affiliated with the Estonian Tax and Customs Board (EMTA) or any Estonian government institution. It requires the emta-cli binary to be built and available on your PATH.
+
+## Prerequisites
+
+Build the EMTA CLI from the [estonia-ai-kit](https://github.com/stefanoamorelli/estonia-ai-kit) repository:
+
+```bash
+# Option 1: go install
+go install github.com/stefanoamorelli/estonia-ai-kit/cli/emta@latest
+
+# Option 2: build from source
+git clone https://github.com/stefanoamorelli/estonia-ai-kit.git
+cd estonia-ai-kit/cli/emta
+go build -o emta-cli .
+```
+
+Ensure the binary is on your PATH.
+
+## Install
+
+```
+/plugin marketplace add stefanoamorelli/estonia-ai-kit
+/plugin install emta@estonia-ai-kit
+```
+
+## Security
+
+This plugin accesses real tax data through an authenticated government session. Review agent actions before approving them.
+
+Further reading: [OWASP Top 10 for LLM Applications](https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/) | [OWASP Top 10 for Agentic Applications](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+
+## License
+
+AGPL-3.0. See [LICENSE](../../LICENSE).
+
+Copyright (c) 2025 [Stefano Amorelli](https://amorelli.tech)

--- a/plugins/emta/skills/emta/SKILL.md
+++ b/plugins/emta/skills/emta/SKILL.md
@@ -1,0 +1,45 @@
+# EMTA CLI Skill
+
+Interact with the Estonian Tax and Customs Board (EMTA) through the `emta-cli` tool. Authenticate via Smart-ID QR code, list and view TSD (Income and Social Tax Return) declarations.
+
+## Pre-flight: Check Authentication
+
+The EMTA CLI uses Smart-ID QR code authentication. Sessions expire after ~30 minutes.
+
+If a command fails with "session expired" or similar, the user needs to re-authenticate:
+
+```bash
+emta-cli login
+```
+
+Login is interactive. A QR code will be displayed in the terminal. Tell the user to scan it with their Smart-ID app. After scanning, the user will be prompted to select a principal (company or person).
+
+To clear the session:
+
+```bash
+emta-cli logout
+```
+
+## Commands
+
+### List TSD declarations
+
+```bash
+emta-cli tsd list              # current year
+emta-cli tsd list --year 2025  # specific year
+```
+
+### Show TSD declaration details
+
+```bash
+emta-cli tsd show <declaration-id>
+```
+
+Get the declaration ID from `tsd list`.
+
+## Important
+
+- Login is always interactive (Smart-ID QR code). Ask the user to scan when running `login`.
+- If you get "session expired", the user needs to run `login` again.
+- Sessions expire after ~30 minutes server-side.
+- Do not hardcode company or person names.

--- a/plugins/lhv/.claude-plugin/plugin.json
+++ b/plugins/lhv/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "lhv",
+  "description": "LHV Bank CLI skill for Claude Code. Authenticate with Smart-ID, view accounts and transactions, switch between personal and business profiles, and make SEPA payments.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Stefano Amorelli",
+    "email": "stefano@amorelli.tech"
+  },
+  "homepage": "https://amorelli.tech",
+  "repository": "https://github.com/stefanoamorelli/estonia-ai-kit",
+  "license": "AGPL-3.0"
+}

--- a/plugins/lhv/README.md
+++ b/plugins/lhv/README.md
@@ -1,0 +1,35 @@
+# LHV Bank Plugin for Claude Code
+
+Claude Code plugin for interacting with LHV Bank. Authenticate with Smart-ID, view accounts and transactions, switch between personal and business profiles, and make SEPA payments.
+
+> [!IMPORTANT]
+> This plugin is experimental and not affiliated with LHV Bank. It requires the [lhv-cli](https://github.com/stefanoamorelli/lhv-cli) binary to be installed and available on your PATH.
+
+## Prerequisites
+
+Install the LHV CLI from [github.com/stefanoamorelli/lhv-cli](https://github.com/stefanoamorelli/lhv-cli):
+
+```bash
+git clone https://github.com/stefanoamorelli/lhv-cli.git
+cd lhv-cli
+make install
+```
+
+## Install
+
+```
+/plugin marketplace add stefanoamorelli/estonia-ai-kit
+/plugin install lhv@estonia-ai-kit
+```
+
+## Security
+
+This plugin can execute real banking operations. Review the [security notice](https://github.com/stefanoamorelli/lhv-cli#lhv-cli) in the lhv-cli repository before use.
+
+Further reading: [OWASP Top 10 for LLM Applications](https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/) | [OWASP Top 10 for Agentic Applications](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+
+## License
+
+AGPL-3.0. See [LICENSE](../../LICENSE).
+
+Copyright (c) 2025 [Stefano Amorelli](https://amorelli.tech)

--- a/plugins/lhv/skills/lhv/SKILL.md
+++ b/plugins/lhv/skills/lhv/SKILL.md
@@ -1,0 +1,104 @@
+# LHV Bank CLI Skill
+
+Interact with LHV Bank through the `lhv` CLI -- check balances, view transactions, switch accounts, and make SEPA payments.
+
+## Pre-flight: Check Authentication
+
+Before any operation, verify the session is valid:
+
+```bash
+lhv whoami
+```
+
+If expired or not authenticated, authenticate first:
+
+```bash
+lhv auth --id <ESTONIAN_ID_CODE>
+```
+
+The auth command will:
+
+1. Initiate Smart-ID authentication
+2. Print a verification code -- tell the user to confirm it on their phone
+3. Wait for smartphone confirmation (up to 2 minutes)
+4. Save session to system keyring
+
+## Discovery: Available Persons
+
+To discover available person/user IDs (personal and business profiles), authenticate first then use:
+
+```bash
+lhv switch-account --list
+```
+
+This outputs JSON, useful for discovering IDs programmatically.
+
+If the user has multiple persons (personal + business), pass `--user-id` and `--account-id` to skip interactive prompts:
+
+```bash
+lhv auth --id <ID_CODE> --user-id <USER_ID> --account-id <ACCOUNT_ID>
+```
+
+## Commands
+
+### Check identity
+
+```bash
+lhv whoami
+```
+
+Shows the authenticated user, active person (Personal/Business), and session status.
+
+### List accounts
+
+```bash
+lhv get-accounts
+```
+
+### View transactions
+
+```bash
+lhv get-transactions --portfolio <PORTFOLIO_ID> --from <DD.MM.YYYY> --to <DD.MM.YYYY>
+```
+
+Defaults to the current month if `--from`/`--to` are omitted. Use `--raw` for CSV output. Use `--limit 0` to show all.
+
+### Switch person/account
+
+List available persons:
+
+```bash
+lhv switch-account --list
+```
+
+Switch non-interactively:
+
+```bash
+lhv switch-account --user-id <USER_ID> --account-id <ACCOUNT_ID>
+```
+
+Use `-i` or `--interactive` to enable the interactive fzf prompt.
+
+### Make a SEPA payment
+
+```bash
+lhv pay \
+  --from "<SENDER_IBAN>" \
+  --to "<RECIPIENT_IBAN>" \
+  --name "<RECIPIENT_NAME>" \
+  --amount "<AMOUNT>" \
+  --description "<DESCRIPTION>" \
+  --reference "<REFERENCE>" \
+  --confirm
+```
+
+The `--confirm` flag skips the interactive confirmation prompt. Smart-ID signing is always required -- print the verification code and tell the user to confirm on their phone.
+
+## Important
+
+- Always run `lhv whoami` before any operation to check session status
+- If session is expired, run `lhv auth` before retrying
+- All interactive/fzf prompts are disabled by default -- pass `--interactive` to enable them
+- For payments, always show the user a summary and ask for confirmation before running the command
+- Smart-ID verification codes timeout after 2 minutes
+- The `--list` flag on `switch-account` outputs JSON, useful for discovering IDs programmatically


### PR DESCRIPTION
The estonia-ai-kit repository currently ships CLI tools (LHV, EMTA) but doesn't provide a standardized way for Claude Code to discover and install them as plugins.

This PR introduces a plugin marketplace structure that makes the existing CLIs installable as Claude Code skills. A top-level `.claude-plugin/marketplace.json` acts as the registry, listing each available plugin with its metadata, and each plugin lives under `plugins/<name>/` with its own `plugin.json` manifest, README, and skill definition.

Two plugins are included:

- **LHV** — wraps the [lhv-cli](https://github.com/stefanoamorelli/lhv-cli) for banking operations (Smart-ID auth, accounts, transactions, SEPA payments).
- **EMTA** — wraps the emta-cli for Estonian Tax and Customs Board operations (Smart-ID auth, TSD declaration listing and viewing).

Each skill file (`SKILL.md`) documents the CLI commands, authentication flows, and important caveats so that Claude Code can operate the tools correctly without hardcoded assumptions.

The structure is designed to be extensible — adding a new plugin is a matter of creating a new directory under `plugins/` and registering it in the marketplace manifest.