### PR TITLE
fix(lhv): load keyring credentials in LoadOptional config

### DIFF
--- a/cli/lhv/internal/config/config.go
+++ b/cli/lhv/internal/config/config.go
@@ -57,6 +57,10 @@ func (c *Config) BuildCookieHeader() string {
 }
 
 func LoadOptional() *Config {
+	if cfg, err := LoadFromKeyring(); err == nil && cfg.IsValid() {
+		return cfg
+	}
+
 	return &Config{
 		SessionID:  os.Getenv("LHV_SESSION_ID"),
 		JSESSIONID: os.Getenv("LHV_JSESSIONID"),


### PR DESCRIPTION
## Summary
- `LoadOptional()` was only reading from environment variables, ignoring credentials stored in the OS keyring
- This caused session lookups (e.g. `lhv whoami`) to fail when using keyring-based auth
- Now tries keyring first before falling back to env vars, matching the behavior of `Load()`

## Test plan
- [x] Verified `lhv whoami` works correctly with keyring-based auth
- [x] Confirmed fallback to env vars still works when keyring is empty