### PR TITLE
fix(lhv): migrate CLI paths and docs to monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ This toolkit covers **government services** (tax, business registry, legal data,
 
 ### 🏦 Private Sector Services
 
-| Package        | Description                       | Type        | Auth     | Status     |
-| -------------- | --------------------------------- | ----------- | -------- | ---------- |
-| `cli/lhv`      | LHV Bank - accounts, transactions | CLI / Skill | Smart-ID | 🔜 Planned |
-| `cli/swedbank` | Swedbank - accounts, transactions | CLI / Skill | Smart-ID | 🔜 Planned |
+| Package                | Description                                 | Type        | Auth     | Status     |
+| ---------------------- | ------------------------------------------- | ----------- | -------- | ---------- |
+| [`cli/lhv`](./cli/lhv) | LHV Bank - accounts, transactions, payments | CLI / Skill | Smart-ID | ✅ Working |
 
 > [!IMPORTANT]
 > **CLI tools that require authentication** (Smart-ID, ID-card) authenticate as _you_ and access _your_ data. Sessions expire after ~30 minutes.
@@ -72,18 +71,28 @@ This toolkit covers **government services** (tax, business registry, legal data,
 ### CLI Tools / Skills
 
 ```bash
-# Build the EMTA CLI
-cd cli/emta
-go build -o emta-cli .
+# Install the EMTA CLI
+go install github.com/stefanoamorelli/estonia-ai-kit/cli/emta@latest
 
-# Login via Smart-ID QR code
-./emta-cli login
+# Install the LHV CLI
+go install github.com/stefanoamorelli/estonia-ai-kit/cli/lhv@latest
+```
 
-# List your TSD declarations
-./emta-cli tsd list
+**EMTA** (Tax & Customs):
 
-# Show declaration details
-./emta-cli tsd show <declaration-id>
+```bash
+emta-cli login                     # Login via Smart-ID QR code
+emta-cli tsd list                  # List your TSD declarations
+emta-cli tsd show <declaration-id> # Show declaration details
+```
+
+**LHV Bank**:
+
+```bash
+lhv auth --interactive             # Authenticate via Smart-ID
+lhv get-accounts                   # List accounts
+lhv get-transactions               # View transactions
+lhv pay --help                     # SEPA payment options
 ```
 
 ### MCP Servers
@@ -113,15 +122,34 @@ Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/
 }
 ```
 
+### Claude Code Plugins
+
+This repository includes a [Claude Code plugin marketplace](https://docs.anthropic.com/en/docs/claude-code/plugins) with ready-to-use skills for AI-assisted workflows.
+
+```bash
+# Add the marketplace (one-time setup)
+/plugin marketplace add stefanoamorelli/estonia-ai-kit
+
+# Install a plugin (e.g., LHV Bank or EMTA)
+/plugin install lhv@estonia-ai-kit
+/plugin install emta@estonia-ai-kit
+```
+
+Each plugin bundles a skill file that teaches Claude Code how to use the corresponding CLI tool. The CLI binary must be installed separately (see Quick Start above).
+
 ## 🛠️ Project Structure
 
 ```
 estonia-ai-kit/
 ├── cli/                       # CLI tools / skills (authenticated services)
-│   └── emta/                  # EMTA Tax & Customs CLI (Go)
+│   ├── emta/                  # EMTA Tax & Customs CLI (Go)
+│   └── lhv/                   # LHV Bank CLI (Go)
 ├── mcp/                       # MCP servers
 │   ├── rik/                   # Business Register
 │   └── open-data/             # Statistics Estonia
+├── plugins/                   # Claude Code plugin marketplace
+│   ├── emta/                  # EMTA plugin + skill
+│   └── lhv/                   # LHV plugin + skill
 ├── packages/                  # Shared TypeScript libraries
 │   ├── shared/                # Common utilities
 │   └── riigiteataja-api-client/
@@ -159,6 +187,7 @@ bun run build
 
 # Go CLI tools
 cd cli/emta && go build -o emta-cli .
+cd cli/lhv && make install
 ```
 
 ### Testing

--- a/cli/lhv/README.md
+++ b/cli/lhv/README.md
@@ -1,4 +1,4 @@
-# lhv-cli
+# LHV CLI
 
 CLI for LHV Bank. Authenticate with Smart-ID, view accounts and transactions, switch between personal and business profiles, and make SEPA payments.
 
@@ -25,8 +25,14 @@ CLI for LHV Bank. Authenticate with Smart-ID, view accounts and transactions, sw
 ## Install
 
 ```bash
-git clone https://github.com/stefanoamorelli/lhv-cli.git
-cd lhv-cli
+go install github.com/stefanoamorelli/estonia-ai-kit/cli/lhv@latest
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/stefanoamorelli/estonia-ai-kit.git
+cd estonia-ai-kit/cli/lhv
 make install
 ```
 
@@ -123,4 +129,4 @@ make clean         # Remove build artifacts
 
 This project is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](LICENSE).
 
-Copyright © 2025 [Stefano Amorelli](https://amorelli.tech) ([stefano@amorelli.tech](mailto:stefano@amorelli.tech))
+Copyright (c) 2025 [Stefano Amorelli](https://amorelli.tech) ([stefano@amorelli.tech](mailto:stefano@amorelli.tech))

--- a/cli/lhv/cmd/auth.go
+++ b/cli/lhv/cmd/auth.go
@@ -10,8 +10,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 const (

--- a/cli/lhv/cmd/get_accounts.go
+++ b/cli/lhv/cmd/get_accounts.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 var getAccountsCmd = &cobra.Command{

--- a/cli/lhv/cmd/get_transactions.go
+++ b/cli/lhv/cmd/get_transactions.go
@@ -10,8 +10,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 var (

--- a/cli/lhv/cmd/logout.go
+++ b/cli/lhv/cmd/logout.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 var logoutCmd = &cobra.Command{

--- a/cli/lhv/cmd/pay.go
+++ b/cli/lhv/cmd/pay.go
@@ -10,8 +10,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 const (

--- a/cli/lhv/cmd/root.go
+++ b/cli/lhv/cmd/root.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 var rootCmd = &cobra.Command{

--- a/cli/lhv/cmd/switch_account.go
+++ b/cli/lhv/cmd/switch_account.go
@@ -7,8 +7,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 var (

--- a/cli/lhv/cmd/whoami.go
+++ b/cli/lhv/cmd/whoami.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/stefanoamorelli/lhv-cli/internal/client"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/client"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 var whoamiCmd = &cobra.Command{

--- a/cli/lhv/go.mod
+++ b/cli/lhv/go.mod
@@ -1,4 +1,4 @@
-module github.com/stefanoamorelli/lhv-cli
+module github.com/stefanoamorelli/estonia-ai-kit/cli/lhv
 
 go 1.25.6
 

--- a/cli/lhv/internal/client/client.go
+++ b/cli/lhv/internal/client/client.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/stefanoamorelli/lhv-cli/internal/config"
+	"github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/internal/config"
 )
 
 type Account struct {

--- a/cli/lhv/main.go
+++ b/cli/lhv/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/stefanoamorelli/lhv-cli/cmd"
+import "github.com/stefanoamorelli/estonia-ai-kit/cli/lhv/cmd"
 
 func main() {
 	cmd.Execute()

--- a/plugins/lhv/README.md
+++ b/plugins/lhv/README.md
@@ -3,15 +3,21 @@
 Claude Code plugin for interacting with LHV Bank. Authenticate with Smart-ID, view accounts and transactions, switch between personal and business profiles, and make SEPA payments.
 
 > [!IMPORTANT]
-> This plugin is experimental and not affiliated with LHV Bank. It requires the [lhv-cli](https://github.com/stefanoamorelli/lhv-cli) binary to be installed and available on your PATH.
+> This plugin is experimental and not affiliated with LHV Bank. It requires the [lhv CLI](https://github.com/stefanoamorelli/estonia-ai-kit/tree/main/cli/lhv) binary to be installed and available on your PATH.
 
 ## Prerequisites
 
-Install the LHV CLI from [github.com/stefanoamorelli/lhv-cli](https://github.com/stefanoamorelli/lhv-cli):
+Install the LHV CLI from the [estonia-ai-kit](https://github.com/stefanoamorelli/estonia-ai-kit) repository:
 
 ```bash
-git clone https://github.com/stefanoamorelli/lhv-cli.git
-cd lhv-cli
+go install github.com/stefanoamorelli/estonia-ai-kit/cli/lhv@latest
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/stefanoamorelli/estonia-ai-kit.git
+cd estonia-ai-kit/cli/lhv
 make install
 ```
 
@@ -24,7 +30,7 @@ make install
 
 ## Security
 
-This plugin can execute real banking operations. Review the [security notice](https://github.com/stefanoamorelli/lhv-cli#lhv-cli) in the lhv-cli repository before use.
+This plugin can execute real banking operations. Review the [security notice](https://github.com/stefanoamorelli/estonia-ai-kit/tree/main/cli/lhv#lhv-cli) before use.
 
 Further reading: [OWASP Top 10 for LLM Applications](https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/) | [OWASP Top 10 for Agentic Applications](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
 


### PR DESCRIPTION
The LHV CLI was originally developed in its own standalone repository (`stefanoamorelli/lhv-cli`) and later moved into this monorepo. However, the Go module path and all internal import paths still referenced the old repository, which meant `go install` from the monorepo path wouldn't work correctly.

This PR updates the Go module declaration and all import paths across the codebase to `github.com/stefanoamorelli/estonia-ai-kit/cli/lhv`, and fixes all documentation (READMEs, install instructions, links) that still pointed to the old repo.

I split this into two commits for clarity: the module path migration in [fefdbee][1], and the documentation updates in [60b9d07][2].

Note: the root README now marks LHV as "Working" and removes the Swedbank placeholder, since only LHV is implemented.

[1]: https://github.com/stefanoamorelli/estonia-ai-kit/commit/fefdbee01602234d3934e9e70f9852b27ff1e170
[2]: https://github.com/stefanoamorelli/estonia-ai-kit/commit/60b9d07881a6faf6eeea7262ad126f5aa5f72b0e