### PR TITLE
feat(lhv): add `balance` command

### DIFF
--- a/cli/lhv/cmd/balance.go
+++ b/cli/lhv/cmd/balance.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/stefanoamorelli/lhv-cli/internal/client"
+	"github.com/stefanoamorelli/lhv-cli/internal/config"
+)
+
+var balanceCmd = &cobra.Command{
+	Use:   "balance",
+	Short: "Show account balances and free funds",
+	Long:  `Fetches the summary statement from LHV and displays balances, interest, reserved amounts, and free funds per account.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			return fmt.Errorf("config error: %w", err)
+		}
+
+		c := client.New(cfg)
+
+		summary, err := c.GetBalances()
+		if err != nil {
+			return fmt.Errorf("failed to get balances: %w", err)
+		}
+
+		if len(summary.Accounts) == 0 {
+			fmt.Println("No balance data found")
+			return nil
+		}
+
+		printBalances(summary)
+		return nil
+	},
+}
+
+func printBalances(s *client.BalanceSummary) {
+	header := color.New(color.FgCyan, color.Bold)
+	name := color.New(color.FgGreen, color.Bold)
+	iban := color.New(color.FgYellow)
+	dim := color.New(color.FgHiBlack)
+	pos := color.New(color.FgGreen, color.Bold)
+	neg := color.New(color.FgRed, color.Bold)
+	totalLbl := color.New(color.FgCyan, color.Bold)
+
+	colorAmount := func(v string) *color.Color {
+		for _, c := range v {
+			if c == '-' {
+				return neg
+			}
+			if c >= '0' && c <= '9' {
+				return pos
+			}
+		}
+		return pos
+	}
+
+	fmt.Println()
+	header.Println("╔════════════════════════════════════════════════════════════════╗")
+	header.Println("║                         LHV BALANCES                           ║")
+	header.Println("╚════════════════════════════════════════════════════════════════╝")
+	fmt.Println()
+
+	for i, b := range s.Accounts {
+		if i > 0 {
+			fmt.Println()
+		}
+
+		name.Printf("  ● %s\n", b.Name)
+		if b.IBAN != "" {
+			fmt.Print("    ")
+			dim.Print("IBAN:       ")
+			iban.Println(b.IBAN)
+		}
+		fmt.Print("    ")
+		dim.Print("Currency:   ")
+		fmt.Println(b.Currency)
+
+		fmt.Print("    ")
+		dim.Print("Balance:    ")
+		colorAmount(b.Balance).Printf("%s %s\n", b.Balance, b.Currency)
+
+		if b.Interest != "" && b.Interest != "0.00" {
+			fmt.Print("    ")
+			dim.Print("Interest:   ")
+			colorAmount(b.Interest).Printf("%s %s\n", b.Interest, b.Currency)
+		}
+
+		if b.Reserved != "" && b.Reserved != "0.00" {
+			fmt.Print("    ")
+			dim.Print("Reserved:   ")
+			fmt.Printf("%s %s\n", b.Reserved, b.Currency)
+		}
+
+		fmt.Print("    ")
+		dim.Print("Free funds: ")
+		colorAmount(b.FreeFunds).Printf("%s %s\n", b.FreeFunds, b.Currency)
+	}
+
+	fmt.Println()
+	dim.Println("─────────────────────────────────────────────────────────────────")
+	if s.TotalBalance != "" {
+		fmt.Print("  ")
+		totalLbl.Print("Total balance:   ")
+		colorAmount(s.TotalBalance).Println(s.TotalBalance)
+	}
+	if s.TotalAvailable != "" {
+		fmt.Print("  ")
+		totalLbl.Print("Total available: ")
+		colorAmount(s.TotalAvailable).Println(s.TotalAvailable)
+	}
+	fmt.Println()
+}
+
+func init() {
+	rootCmd.AddCommand(balanceCmd)
+}

--- a/cli/lhv/internal/client/client.go
+++ b/cli/lhv/internal/client/client.go
@@ -26,6 +26,23 @@ type Account struct {
 	Cards       []Account
 }
 
+type Balance struct {
+	Name      string
+	IBAN      string
+	Currency  string
+	ExchRate  string
+	Balance   string
+	Interest  string
+	Reserved  string
+	FreeFunds string
+}
+
+type BalanceSummary struct {
+	Accounts       []Balance
+	TotalBalance   string
+	TotalAvailable string
+}
+
 type UserEntry struct {
 	UserID   int64  `json:"userId"`
 	Name     string `json:"name"`
@@ -282,6 +299,96 @@ func (c *Client) GetAccounts() ([]Account, error) {
 	}
 
 	return accounts, nil
+}
+
+func (c *Client) GetBalances() (*BalanceSummary, error) {
+	endpoint := baseURL + "/portfolio/view.cfm?newframe=1&l3=en&vi=0&show_loan=0"
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	req.Header.Set("Referer", baseURL+"/ibank/cf/portfolio/view")
+	req.Header.Set("Cookie", c.config.BuildCookieHeader())
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var reader io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	}
+
+	doc, err := goquery.NewDocumentFromReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse HTML: %w", err)
+	}
+
+	summary := &BalanceSummary{}
+	table := doc.Find("div#view_money table.grid").First()
+	if table.Length() == 0 {
+		return nil, fmt.Errorf("balance table not found")
+	}
+
+	table.Find("tbody tr").Each(func(i int, row *goquery.Selection) {
+		cells := row.ChildrenFiltered("td")
+		n := cells.Length()
+		if n < 6 {
+			return
+		}
+
+		b := Balance{
+			FreeFunds: strings.TrimSpace(cells.Eq(n - 1).Text()),
+			Reserved:  strings.TrimSpace(cells.Eq(n - 2).Text()),
+			Interest:  strings.TrimSpace(cells.Eq(n - 3).Text()),
+			Balance:   strings.TrimSpace(cells.Eq(n - 4).Text()),
+			ExchRate:  strings.TrimSpace(cells.Eq(n - 5).Text()),
+			Currency:  strings.TrimSpace(cells.Eq(n - 6).Text()),
+		}
+
+		nameText := ""
+		for j := 0; j <= n-7; j++ {
+			t := strings.TrimSpace(cells.Eq(j).Text())
+			if t != "" {
+				nameText = t
+			}
+		}
+		if strings.Contains(nameText, "•") {
+			parts := strings.SplitN(nameText, "•", 2)
+			b.Name = strings.TrimSpace(parts[0])
+			b.IBAN = strings.TrimSpace(parts[1])
+		} else {
+			b.Name = nameText
+		}
+
+		if b.Name == "" && b.Balance == "" && b.FreeFunds == "" {
+			return
+		}
+
+		summary.Accounts = append(summary.Accounts, b)
+	})
+
+	summary.TotalBalance = strings.TrimSpace(table.Find("tfoot .money-balance").Text())
+	summary.TotalAvailable = strings.TrimSpace(table.Find("tfoot .money-available").Text())
+
+	return summary, nil
 }
 
 func extractLast4Digits(text string) string {


### PR DESCRIPTION
The `lhv` CLI lists accounts via `get-accounts` but exposes no way to see how much money is actually in them. Looking at the LHV web banking app, the JSON endpoint at `/b/accounts` only returns account metadata (id, IBAN, type, status). The balance values themselves are rendered server-side into the legacy ColdFusion summary statement at `/portfolio/view.cfm` and embedded as plain text in the page.

I followed the same scraping pattern the CLI already uses for `GetAccounts` (which parses `/portfolio/reports_cur.cfm` with goquery): fetch the HTML using the existing cookie-based session, find `#view_money table.grid`, and pull values per row. Sub-product rows like the credit account have an extra indent cell, so the parser reads amount columns from the right and treats the remaining leading cells as the name. Names containing "•" are split into name and IBAN, matching the format the page uses for primary accounts.

The new `lhv balance` command prints, for each account, the balance, accrued interest, reserved amount, and free funds, plus the totals from the table footer (`money-balance` / `money-available`).

Example output:

```
╔════════════════════════════════════════════════════════════════╗
║                         LHV BALANCES                           ║
╚════════════════════════════════════════════════════════════════╝

  ● Stefano Amorelli
    IBAN:       EE49770077XXXXXXXXXXX
    Currency:   EUR
    Balance:    194.81 EUR
    Free funds: 194.81 EUR

  ● Credit account
    Currency:   EUR
    Balance:    -746.59 EUR
    Interest:   -2.56 EUR
    Free funds: 553.41 EUR

  Total balance:   -551.78 EUR
  Total available: 748.22 EUR
```

Note: this scrapes legacy HTML, so it will break if LHV changes the markup of the summary statement. There is no JSON endpoint that returns balances; the `/b/...` APIs only carry account metadata.