### PR TITLE
fix(lhv): read session from keyring in `whoami`

### DIFF
--- a/cli/lhv/cmd/whoami.go
+++ b/cli/lhv/cmd/whoami.go
@@ -14,9 +14,8 @@ var whoamiCmd = &cobra.Command{
 	Short: "Show current authenticated user",
 	Long:  `Displays information about the currently authenticated LHV user.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := config.LoadOptional()
-
-		if !cfg.IsValid() {
+		cfg, err := config.Load()
+		if err != nil || !cfg.IsValid() {
 			red := color.New(color.FgRed)
 			red.Println("\n  ✗ Not authenticated")
 			fmt.Println()


### PR DESCRIPTION
## What

`lhv whoami` now loads the session via `config.Load()` (keyring-first) instead of `config.LoadOptional()` (environment-only).

## Why

`whoami` reported `✗ Not authenticated` even when a valid session existed, while `pay` and `switch-account` worked fine against the same session. It was the only command using `LoadOptional()`, which reads only environment variables / `.env.local` and never checks the system keyring where `lhv auth` persists the login. Every other command already uses `config.Load()`, which tries the keyring first.

## Change

Swap `LoadOptional()` for `Load()` and treat a load error the same as an invalid config, so the "Not authenticated" hint still shows when there genuinely is no session.

Verified locally: `whoami` now reports the logged-in user instead of a false negative.