### PR TITLE
chore: require DCO sign-off and CLA on contributions

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,45 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  cla:
+    name: Contributor License Agreement
+    runs-on: ubuntu-latest
+    # Run on PR events, or when someone comments the sign/recheck phrases.
+    if: |
+      (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+      (github.event.comment.body == 'recheck') ||
+      github.event_name == 'pull_request_target'
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Signatures are stored in a JSON file on a dedicated branch of
+          # this same repo — no external service required.
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: stefanoamorelli,dependabot[bot],bot*
+          custom-notsigned-prcomment: >
+            Thank you for your contribution! Before we can merge it, we need you
+            to agree to the [Contributor License Agreement](https://github.com/${{ github.repository }}/blob/main/CLA.md).
+            Please read it, then post the following comment in this PR to sign:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,54 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dco-check:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by on every commit
+        run: |
+          # Every commit in the PR must carry a `Signed-off-by:` trailer
+          # (added with `git commit -s`), certifying the Developer
+          # Certificate of Origin 1.1 — https://developercertificate.org
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          missing=0
+          while read -r sha; do
+            [ -z "$sha" ] && continue
+            if ! git show -s --format=%B "$sha" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+              subject=$(git show -s --format=%s "$sha")
+              echo "::error::Commit $sha is missing a Signed-off-by line: $subject"
+              missing=1
+            fi
+          done < <(git rev-list "$base".."$head")
+
+          if [ "$missing" -ne 0 ]; then
+            echo ""
+            echo "One or more commits are not signed off."
+            echo "Fix it by amending with sign-off:"
+            echo "    git commit --amend -s        # for the latest commit"
+            echo "    git rebase --signoff $base    # to sign off the whole branch"
+            echo "Then force-push your branch."
+            exit 1
+          fi
+
+          echo "All commits are signed off. ✅"

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,133 @@
+# Contributor License Agreement
+
+> This is the **Apache Software Foundation Individual Contributor License
+> Agreement V2.2** (sections 1–8 reproduced verbatim), adapted only so that the
+> rights are granted to the maintainer of this project rather than to the
+> Apache Software Foundation, plus one explicitly-marked relicensing clause in
+> Section 2. See <https://www.apache.org/licenses/contributor-agreements.html>.
+
+Thank you for your interest in **Estonia AI Kit** (the "Project"), maintained by
+Stefano Amorelli (the "Maintainer"). To clarify the intellectual property
+license granted with Contributions from any person or entity, the Maintainer
+must have on file a signed Contributor License Agreement ("CLA") from each
+Contributor, indicating agreement with the license terms below. This agreement
+is for your protection as a Contributor as well as the protection of the Project
+and its users. It does not change your rights to use your own Contributions for
+any other purpose.
+
+You accept and agree to the following terms and conditions for Your
+Contributions (present and future) that you submit to the Project. In return,
+the Maintainer shall not use Your Contributions in a way that is contrary to the
+purpose and mission of the Project as in effect at the time of the Contribution.
+Except for the license granted herein to the Maintainer and recipients of
+software distributed by the Project, You reserve all right, title, and interest
+in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is making this Agreement with the Maintainer. For legal
+entities, the entity making a Contribution and all other entities that control,
+are controlled by, or are under common control with that entity are considered
+to be a single Contributor. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+entity.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Maintainer for inclusion in, or documentation of, any of the
+products owned or managed by the Project (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to the Maintainer or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of, the
+Maintainer for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing by
+You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Project a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license
+to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+> **Relicensing (project-specific addition).** You further agree that the
+> Maintainer may license, relicense, and distribute Your Contributions and
+> derivative works under any license terms, including the Project's current
+> license (AGPL-3.0), any other open-source license, and/or proprietary or
+> commercial license terms. This permits the Maintainer to dual-license the
+> Project and to do everything reasonably necessary to maintain, distribute, and
+> commercialize it.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Maintainer and to recipients of software distributed by the Project a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+in this section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Work, where such license applies only to
+those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work to
+which such Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that your Contribution, or the Work to which
+you have contributed, constitutes direct or contributory patent infringement,
+then any patent licenses granted to that entity under this Agreement for that
+Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4.
+
+You represent that you are legally entitled to grant the above license. If your
+employer(s) has rights to intellectual property that you create that includes
+your Contributions, you represent that you have received permission to make
+Contributions on behalf of that employer, that your employer has waived such
+rights for your Contributions to the Maintainer, or that your employer has
+executed a separate Corporate CLA with the Maintainer.
+
+## 5.
+
+You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which you are personally aware and which are associated with any
+part of Your Contributions.
+
+## 6.
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without limitation,
+any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7.
+
+Should You wish to submit work that is not Your original creation, You may submit
+it to the Maintainer separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including, but
+not limited to, related patents, trademarks, and license agreements) of which
+you are personally aware, and conspicuously marking the work as "Submitted on
+behalf of a third-party: [named here]".
+
+## 8.
+
+You agree to notify the Maintainer of any facts or circumstances of which you
+become aware that would make these representations inaccurate in any respect.
+
+## How to Sign
+
+You sign this Agreement by **commenting on your pull request** with exactly:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+An automated assistant records your signature against your GitHub username,
+along with the comment, a timestamp, and the relevant commit. You only need to
+sign once; the signature applies to all of your future Contributions to the
+Project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to Estonia AI Kit
+
+Thanks for your interest in contributing! 🇪🇪 This guide covers the two
+agreements every contribution must satisfy before it can be merged.
+
+## TL;DR
+
+1. **Sign off your commits** with `git commit -s` (Developer Certificate of
+   Origin).
+2. **Sign the CLA once** by commenting on your first pull request.
+
+Both are checked automatically on every pull request.
+
+## 1. Developer Certificate of Origin (DCO)
+
+Every commit must carry a `Signed-off-by` line. This is your statement that you
+wrote the code (or otherwise have the right to submit it) under the project
+license — see [developercertificate.org](https://developercertificate.org).
+
+Add it automatically with the `-s` flag:
+
+```bash
+git commit -s -m "feat: add my change"
+```
+
+This appends a trailer like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Forgot to sign off? Fix it before pushing:
+
+```bash
+git commit --amend -s            # the latest commit
+git rebase --signoff origin/main # the whole branch
+git push --force-with-lease
+```
+
+The **DCO** check enforces this on every commit in your PR.
+
+## 2. Contributor License Agreement (CLA)
+
+The DCO certifies *where the code came from*. The [CLA](./CLA.md) goes one step
+further: it grants the maintainer the rights needed to distribute, relicense,
+and commercialize the project (for example, to dual-license it). You keep the
+copyright to your contributions.
+
+You only sign **once**. On your first pull request, an automated assistant will
+ask you to comment:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded against your GitHub username and applies to all your
+future contributions.
+
+## Pull request checklist
+
+- [ ] Commits are signed off (`git commit -s`)
+- [ ] CLA signed (one-time, via PR comment)
+- [ ] Tests and linters pass locally (`npx nx affected --target=test,lint`)
+- [ ] The PR description explains **why** the change is needed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ The **DCO** check enforces this on every commit in your PR.
 
 ## 2. Contributor License Agreement (CLA)
 
-The DCO certifies *where the code came from*. The [CLA](./CLA.md) goes one step
+The DCO certifies _where the code came from_. The [CLA](./CLA.md) goes one step
 further: it grants the maintainer the rights needed to distribute, relicense,
 and commercialize the project (for example, to dual-license it). You keep the
 copyright to your contributions.


### PR DESCRIPTION
## Why

Right now anyone can open a PR with no record of **where the code came from** or **what rights we have to it**. With the project under AGPL-3.0 only, contributions are locked to that license.

This adds the two standard mechanisms that fix both, using **free GitHub Actions with no external service**.

## How contributors are affected

1. Sign off commits with `git commit -s`.
2. On their first PR, comment once: *"I have read the CLA Document and I hereby sign the CLA"*.

Both are checked automatically.

## Follow-up (manual, after merge)

Add **"CLA Assistant"** and **"Developer Certificate of Origin"** as required status checks in branch protection for `main` — otherwise they run but don't block merges.