### PR TITLE
fix(emta): unify binary name to emta (drop -cli suffix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ go install github.com/stefanoamorelli/estonia-ai-kit/cli/lhv@latest
 **EMTA** (Tax & Customs):
 
 ```bash
-emta-cli login                     # Login via Smart-ID QR code
-emta-cli tsd list                  # List your TSD declarations
-emta-cli tsd show <declaration-id> # Show declaration details
+emta login                     # Login via Smart-ID QR code
+emta tsd list                  # List your TSD declarations
+emta tsd show <declaration-id> # Show declaration details
 ```
 
 **LHV Bank**:
@@ -186,7 +186,7 @@ bun install
 bun run build
 
 # Go CLI tools
-cd cli/emta && go build -o emta-cli .
+cd cli/emta && go build -o emta .
 cd cli/lhv && make install
 ```
 

--- a/cli/emta/.gitignore
+++ b/cli/emta/.gitignore
@@ -1,1 +1,2 @@
+emta
 emta-cli

--- a/cli/emta/CLAUDE.md
+++ b/cli/emta/CLAUDE.md
@@ -1,13 +1,13 @@
-# emta-cli
+# emta
 
-CLI for Estonian Tax and Customs Board (EMTA) e-services. Binary at `./emta-cli` (or build with `go build -o emta-cli .`).
+CLI for Estonian Tax and Customs Board (EMTA) e-services. Binary at `./emta` (or build with `go build -o emta .`).
 
 ## Using the CLI
 
 ### Login (interactive, requires user to scan QR code)
 
 ```sh
-./emta-cli login
+./emta login
 ```
 
 Session is stored in the OS keychain (encrypted). Expires after ~30 minutes.
@@ -15,20 +15,20 @@ Session is stored in the OS keychain (encrypted). Expires after ~30 minutes.
 ### Logout
 
 ```sh
-./emta-cli logout
+./emta logout
 ```
 
 ### List TSD declarations
 
 ```sh
-./emta-cli tsd list              # current year
-./emta-cli tsd list --year 2025  # specific year
+./emta tsd list              # current year
+./emta tsd list --year 2025  # specific year
 ```
 
 ### Show TSD declaration summary (tax codes 110-119)
 
 ```sh
-./emta-cli tsd show <declaration-id>
+./emta tsd show <declaration-id>
 ```
 
 Get the declaration ID from `tsd list`.

--- a/cli/emta/README.md
+++ b/cli/emta/README.md
@@ -27,7 +27,7 @@ Or build from source:
 
 ```sh
 cd cli/emta
-go build -o emta-cli .
+go build -o emta .
 ```
 
 ## Usage
@@ -37,7 +37,7 @@ go build -o emta-cli .
 Authenticate via Smart-ID QR code. You'll be prompted to select a principal (company/person) after scanning.
 
 ```sh
-./emta-cli login
+./emta login
 ```
 
 Session is stored in the OS keychain (macOS Keychain, GNOME Keyring, Windows Credential Manager) and expires after ~30 minutes server-side.
@@ -45,20 +45,20 @@ Session is stored in the OS keychain (macOS Keychain, GNOME Keyring, Windows Cre
 To clear the saved session:
 
 ```sh
-./emta-cli logout
+./emta logout
 ```
 
 ### List TSD Declarations
 
 ```sh
-./emta-cli tsd list              # current year
-./emta-cli tsd list --year 2025  # specific year
+./emta tsd list              # current year
+./emta tsd list --year 2025  # specific year
 ```
 
 ### Show TSD Summary
 
 ```sh
-./emta-cli tsd show <declaration-id>
+./emta tsd show <declaration-id>
 ```
 
 Get the declaration ID from `tsd list`.

--- a/cli/emta/api/client.go
+++ b/cli/emta/api/client.go
@@ -80,7 +80,7 @@ func (c *Client) ensureSession() error {
 	finalURL := resp.Request.URL.String()
 
 	if strings.Contains(finalURL, "/v1/login") {
-		return fmt.Errorf("session expired. Please run 'emta-cli login' again")
+		return fmt.Errorf("session expired. Please run 'emta login' again")
 	}
 
 	// Direct access worked

--- a/cli/emta/cmd/root.go
+++ b/cli/emta/cmd/root.go
@@ -20,7 +20,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "emta-cli",
+	Use:   "emta",
 	Short: "CLI for Estonian Tax and Customs Board (EMTA) e-services",
 }
 
@@ -47,6 +47,8 @@ type sessionFile struct {
 }
 
 const (
+	// keyringService keeps the "-cli" suffix (matching lhv's "lhv-cli") so existing
+	// stored sessions remain valid after the binary was renamed from emta-cli to emta.
 	keyringService = "emta-cli"
 	keyringUser    = "session"
 )
@@ -101,7 +103,7 @@ func saveSession(s *auth.Session) error {
 func loadSession() (*auth.Session, error) {
 	data, err := keyring.Get(keyringService, keyringUser)
 	if err != nil {
-		return nil, fmt.Errorf("not logged in. Run 'emta-cli login' first")
+		return nil, fmt.Errorf("not logged in. Run 'emta login' first")
 	}
 	var sf sessionFile
 	if err := json.Unmarshal([]byte(data), &sf); err != nil {

--- a/plugins/emta/README.md
+++ b/plugins/emta/README.md
@@ -3,7 +3,7 @@
 Claude Code plugin for interacting with the Estonian Tax and Customs Board (EMTA). Authenticate via Smart-ID QR code, list and view TSD (Income and Social Tax Return) declarations.
 
 > [!IMPORTANT]
-> This plugin is experimental and not affiliated with the Estonian Tax and Customs Board (EMTA) or any Estonian government institution. It requires the emta-cli binary to be built and available on your PATH.
+> This plugin is experimental and not affiliated with the Estonian Tax and Customs Board (EMTA) or any Estonian government institution. It requires the emta binary to be built and available on your PATH.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ go install github.com/stefanoamorelli/estonia-ai-kit/cli/emta@latest
 # Option 2: build from source
 git clone https://github.com/stefanoamorelli/estonia-ai-kit.git
 cd estonia-ai-kit/cli/emta
-go build -o emta-cli .
+go build -o emta .
 ```
 
 Ensure the binary is on your PATH.

--- a/plugins/emta/skills/emta/SKILL.md
+++ b/plugins/emta/skills/emta/SKILL.md
@@ -1,6 +1,6 @@
 # EMTA CLI Skill
 
-Interact with the Estonian Tax and Customs Board (EMTA) through the `emta-cli` tool. Authenticate via Smart-ID QR code, list and view TSD (Income and Social Tax Return) declarations.
+Interact with the Estonian Tax and Customs Board (EMTA) through the `emta` tool. Authenticate via Smart-ID QR code, list and view TSD (Income and Social Tax Return) declarations.
 
 ## Pre-flight: Check Authentication
 
@@ -9,7 +9,7 @@ The EMTA CLI uses Smart-ID QR code authentication. Sessions expire after ~30 min
 If a command fails with "session expired" or similar, the user needs to re-authenticate:
 
 ```bash
-emta-cli login
+emta login
 ```
 
 Login is interactive. A QR code will be displayed in the terminal. Tell the user to scan it with their Smart-ID app. After scanning, the user will be prompted to select a principal (company or person).
@@ -17,7 +17,7 @@ Login is interactive. A QR code will be displayed in the terminal. Tell the user
 To clear the session:
 
 ```bash
-emta-cli logout
+emta logout
 ```
 
 ## Commands
@@ -25,14 +25,14 @@ emta-cli logout
 ### List TSD declarations
 
 ```bash
-emta-cli tsd list              # current year
-emta-cli tsd list --year 2025  # specific year
+emta tsd list              # current year
+emta tsd list --year 2025  # specific year
 ```
 
 ### Show TSD declaration details
 
 ```bash
-emta-cli tsd show <declaration-id>
+emta tsd show <declaration-id>
 ```
 
 Get the declaration ID from `tsd list`.


### PR DESCRIPTION
Renames the `emta-cli` binary to `emta` so `go install` matches the docs and the `lhv` CLI convention. Closes #10.